### PR TITLE
added Jekyll include file for HTML5 video player

### DIFF
--- a/docs/_includes/html5_video.html
+++ b/docs/_includes/html5_video.html
@@ -1,0 +1,9 @@
+{% if include.title %}
+<h2 style="text-align:left;">{{include.title}}</h2><hr>
+{% else %}
+<h2 style="text-align:left;">Video : Click to play</h2><hr>
+{% endif %}
+<video width="600" controls poster="{{include.poster}}">
+  <source src="{{include.url}}" type="video/ogg">
+  Your browser does not support HTML5 video.
+</video>


### PR DESCRIPTION
embed videos using the HTML5 video player . Also has support for adding a title, and a poster.
Example text for embedding sample_video.ogg in a doc file
`{% include html5_video.html poster="images/poster.jpg" url="screencasts/sample_video.ogg" title = "this is the title : Click to play video" %}` 

Videos have fixed width at 600px , and options need to be explored for fluid width for html5 video

fixes #150 