### PR TITLE
docs: added dialog box to open Desktop app

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -62,10 +62,7 @@ make install
 
 echo -e "${GREEN}Desktop application installed!${NOCOLOR}"
 
-echo -en "${YELLOW}Do you want to open PSLab Application now $*? [y/n] ${NOCOLOR}"
-read -N 1 REPLY
-echo
-if test "$REPLY" = "y" -o "$REPLY" = "Y"; then
+if (whiptail --title "Open PSLab Desktop Application" --yesno "Do you want to open PSLab Application now?" 8 46) then
 	echo -e "${GREEN}Starting application!${NOCOLOR}"
 	Experiments
 else


### PR DESCRIPTION
Fixes #198 

When the installation is complete, confirmation to open PSLab desktop app will be asked using a dialog box.

![dialog](https://user-images.githubusercontent.com/14261304/39227857-8e12c896-4878-11e8-82bb-7d2e3327670c.png)
