### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/PSL_Apps/saveProfile.py
+++ b/PSL_Apps/saveProfile.py
@@ -1,6 +1,6 @@
 #===================================================================
 # Module with functions to save & restore qt widget values
-# Written by: Alan Lilly 
+# Written by: Alan Lilly
 # Website: http://panofish.net
 #===================================================================
 

--- a/PSL_Apps/saveProfile.py
+++ b/PSL_Apps/saveProfile.py
@@ -11,9 +11,14 @@
 #
 #===================================================================
 
-import sys
-from PyQt4 import QtCore, QtGui
 import inspect
+import sys
+from PyQt4 import QtGui
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 #===================================================================
 # save "ui" controls and values to registry "setting"

--- a/PSL_Apps/utilitiesClass.py
+++ b/PSL_Apps/utilitiesClass.py
@@ -1,18 +1,47 @@
-import time,random,functools,pkgutil,importlib,functools,pkg_resources
+import functools
+import importlib
+import numbers
+import os
+import random
+import sys
 
-import os,numbers
-os.environ['QT_API'] = 'pyqt'
+import pkg_resources
+
+import numpy as np
+import pyqtgraph as pg
 import sip
+from PSL_Apps import saveProfile
+from PSL_Apps.templates.widgets import ui_button as button
+from PSL_Apps.templates.widgets import ui_dial as dial
+from PSL_Apps.templates.widgets import \
+    ui_dialAndDoubleSpin as dialAndDoubleSpin
+from PSL_Apps.templates.widgets import ui_displayWidget as displayWidget
+from PSL_Apps.templates.widgets import ui_doubleSpinBox as doubleSpinBox
+from PSL_Apps.templates.widgets import ui_dualButton as dualButton
+from PSL_Apps.templates.widgets import ui_gainWidget as gainWidget
+from PSL_Apps.templates.widgets import \
+    ui_gainWidgetCombined as gainWidgetCombined
+from PSL_Apps.templates.widgets import ui_pulseCounter as pulseCounter
+from PSL_Apps.templates.widgets import ui_pwmWidget as pwmWidget
+from PSL_Apps.templates.widgets import ui_selectAndButton as selectAndButton
+from PSL_Apps.templates.widgets import ui_sensorWidget as sensorWidget
+from PSL_Apps.templates.widgets import ui_setStateList as setStateList
+from PSL_Apps.templates.widgets import ui_simpleButton as simpleButton
+from PSL_Apps.templates.widgets import ui_sineWidget as sineWidget
+from PSL_Apps.templates.widgets import ui_spinBox as spinBox
+from PSL_Apps.templates.widgets import ui_supplyWidget as supplyWidget
+from PSL_Apps.templates.widgets import ui_voltWidget as voltWidget
+from PSL_Apps.templates.widgets import ui_widebutton as widebutton
+from PyQt4 import QtCore, QtGui
+
+os.environ['QT_API'] = 'pyqt'
 sip.setapi("QString", 2)
 sip.setapi("QVariant", 2)
 
-from PyQt4 import QtCore, QtGui
-import pyqtgraph as pg
-from PSL_Apps.templates.widgets import ui_dial as dial,ui_button as button,ui_selectAndButton as selectAndButton,ui_sineWidget as sineWidget,ui_pwmWidget as pwmWidget,ui_supplyWidget as supplyWidget,ui_setStateList as setStateList,ui_sensorWidget as sensorWidget,ui_simpleButton as simpleButton, ui_dualButton as dualButton
-from PSL_Apps.templates.widgets import ui_spinBox as spinBox,ui_doubleSpinBox as doubleSpinBox,ui_dialAndDoubleSpin as dialAndDoubleSpin,ui_pulseCounter as pulseCounter,ui_voltWidget as voltWidget,ui_gainWidget as gainWidget,ui_gainWidgetCombined as gainWidgetCombined,ui_widebutton as widebutton,ui_displayWidget as displayWidget
-from PSL_Apps import saveProfile
-from PSL.commands_proto import applySIPrefix
-import numpy as np
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -1513,5 +1542,3 @@ class utilitiesClass():
 			self.studioWidgets[name]=WG
 			return WG
 		return None
-
-

--- a/PSL_Apps/utilityApps/advancedCal.py
+++ b/PSL_Apps/utilityApps/advancedCal.py
@@ -112,7 +112,7 @@ class AppWindow(QtGui.QMainWindow, advancedCal.Ui_MainWindow,utilitiesClass):
 					else:
 						print ('Done',V,C,CT)
 						return C
-		except Exception, ex:
+		except Exception as ex:
 			self.displayDialog(ex.message)
 
 

--- a/PSL_Apps/utilityApps/deviceInfo.py
+++ b/PSL_Apps/utilityApps/deviceInfo.py
@@ -12,8 +12,12 @@ sip.setapi("QVariant", 2)
 
 from PyQt4 import QtCore, QtGui
 from .templates import ui_aboutDevice as aboutDevice
-import sys,os,time
+import sys
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 
 class AppWindow(QtGui.QMainWindow, aboutDevice.Ui_MainWindow):

--- a/PSL_Apps/utilityApps/plotSaveWindow.py
+++ b/PSL_Apps/utilityApps/plotSaveWindow.py
@@ -12,9 +12,13 @@ sip.setapi("QVariant", 2)
 
 from PyQt4 import QtCore, QtGui
 from templates import ui_plotSave as plotSave
-import sys,os,time
+import sys
 import pyqtgraph as pg
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 
 class AppWindow(QtGui.QMainWindow, plotSave.Ui_MainWindow):

--- a/PSL_Apps/utilityApps/spreadsheet.py
+++ b/PSL_Apps/utilityApps/spreadsheet.py
@@ -12,8 +12,12 @@ sip.setapi("QVariant", 2)
 
 from PyQt4 import QtCore, QtGui
 from .templates import ui_aboutDevice as aboutDevice
-import sys,os,time
+import sys
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 
 class AppWindow(QtGui.QMainWindow, aboutDevice.Ui_MainWindow):

--- a/psl_res/GUI/A_TEST_AND_MEASUREMENT/A_TandM/Z_designer.py
+++ b/psl_res/GUI/A_TEST_AND_MEASUREMENT/A_TandM/Z_designer.py
@@ -5,24 +5,31 @@ design experiments
 '''
 from __future__ import print_function
 
-from PSL.SENSORS.supported import supported as I2CSensors
-from PSL.SENSORS.supported import nameMap as I2CSensorsNameMap
+import functools
+import numbers
+import sys
+import time
 
-from PSL_Apps.utilitiesClass import utilitiesClass
+from pkg_resources import resource_filename, resource_listdir
+
+import numpy as np
+import pyqtgraph as pg
+from PSL.SENSORS.supported import nameMap as I2CSensorsNameMap
+from PSL.SENSORS.supported import supported as I2CSensors
 from PSL_Apps.templates import ui_designer as designer
+from PSL_Apps.templates.widgets.ui_customFunc import Ui_Form as ui_custom
+from PSL_Apps.templates.widgets.ui_customSensor import \
+    Ui_Form as ui_customSensor
+from PSL_Apps.templates.widgets.ui_customSweep import Ui_Form as ui_customSweep
 from PSL_Apps.templates.widgets.ui_sweep import Ui_Form as ui_sweep
 from PSL_Apps.templates.widgets.ui_sweepTitle import Ui_Form as ui_sweepTitle
-from PSL_Apps.templates.widgets.ui_customFunc import Ui_Form as ui_custom
-from PSL_Apps.templates.widgets.ui_customSensor import Ui_Form as ui_customSensor
-from PSL_Apps.templates.widgets.ui_customSweep import Ui_Form as ui_customSweep
-
-import pyqtgraph as pg
-import time,random,functools,numbers,importlib,os,sys
-from pkg_resources import resource_listdir,resource_filename
-import numpy as np
-
-
+from PSL_Apps.utilitiesClass import utilitiesClass
 from PyQt4 import QtCore, QtGui
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 params = {
 'image' : 'sensors.png',

--- a/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_DiodeClamping.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_DiodeClamping.py
@@ -148,7 +148,7 @@ class AppWindow(QtGui.QMainWindow, template_graph.Ui_MainWindow,utilitiesClass):
 			self.displayCrossHairData(self.plot,self.fftMode,self.samples,self.I.timebase,[self.I.achans[0].get_yaxis(),self.I.achans[1].get_yaxis()],[(0,255,0),(255,0,0)])
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_DiodeClipping.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_DiodeClipping.py
@@ -152,7 +152,7 @@ class AppWindow(QtGui.QMainWindow, template_graph.Ui_MainWindow,utilitiesClass):
 			self.displayCrossHairData(self.plot,self.fftMode,self.samples,self.I.timebase,[self.I.achans[0].get_yaxis(),self.I.achans[1].get_yaxis()],[(0,255,0),(255,0,0)])
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_halfWave.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Diodes/L_halfWave.py
@@ -148,7 +148,7 @@ class AppWindow(QtGui.QMainWindow, template_graph.Ui_MainWindow,utilitiesClass):
 			self.displayCrossHairData(self.plot,self.fftMode,self.samples,self.I.timebase,[self.I.achans[0].get_yaxis(),self.I.achans[1].get_yaxis()],[(0,255,0),(255,0,0)])
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Diodes/M_FullWave.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Diodes/M_FullWave.py
@@ -123,7 +123,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 			self.plot.setLimits(xMax = xlen)
 			self.plot.setXRange(0,xlen)
 			return xlen
-		except Exception,e:
+		except Exception as e:
 			print(e)
 		
 	def closeEvent(self, event):

--- a/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_Inverting.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_Inverting.py
@@ -155,7 +155,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 				
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_LinearRampGen.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_LinearRampGen.py
@@ -109,7 +109,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 			#self.displayCrossHairData(self.plot,False,self.samples,self.I.timebase,[y],[(0,255,0)])
 			self.I.set_state(SQR1=False) #Set SQR1 to 0
 			return 'Done'
-		except Exception,e:
+		except Exception as e:
 			print (e)
 			return 'Error'
 

--- a/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_NonInverting.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Opamps/L_NonInverting.py
@@ -155,7 +155,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 				
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Opamps/Precision_Rectifier.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Opamps/Precision_Rectifier.py
@@ -144,7 +144,7 @@ class AppWindow(QtGui.QMainWindow, template_graph.Ui_MainWindow,utilitiesClass):
 			self.displayCrossHairData(self.plot,self.fftMode,self.samples,self.I.timebase,[self.I.achans[0].get_yaxis(),self.I.achans[1].get_yaxis()],[(0,255,0),(255,0,0)])
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Oscillators/L_WIEN_BRIDGE.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Oscillators/L_WIEN_BRIDGE.py
@@ -146,7 +146,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 
 		
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/B_ELECTRONICS/B_Oscillators/M_Monostable.py
+++ b/psl_res/GUI/B_ELECTRONICS/B_Oscillators/M_Monostable.py
@@ -122,7 +122,7 @@ class AppWindow(QtGui.QMainWindow, template_graph_nofft.Ui_MainWindow,utilitiesC
 			self.curveCH2.setData(x*1e-6,self.I.achans[1].get_yaxis())
 			#self.displayCrossHairData(self.plot,False,self.samples,self.I.timebase,[y],[(0,255,0)])
 			return 'Done'
-		except Exception,e:
+		except Exception as e:
 			print (e)
 			return 'Error'
 

--- a/psl_res/GUI/C_ELECTRICAL/D_electrical/Q_RC_integ_deriv.py
+++ b/psl_res/GUI/C_ELECTRICAL/D_electrical/Q_RC_integ_deriv.py
@@ -141,7 +141,7 @@ class AppWindow(QtGui.QMainWindow, template_graph.Ui_MainWindow,utilitiesClass):
 			self.displayCrossHairData(self.plot,self.fftMode,self.samples,self.I.timebase,[self.I.achans[0].get_yaxis(),self.I.achans[1].get_yaxis()],[(0,255,0),(255,0,0)])
 			
 			if self.running:self.timer.singleShot(100,self.run)
-		except Exception,e:
+		except Exception as e:
 			print (e)
 
 	def saveData(self):

--- a/psl_res/GUI/D_PHYSICS/B_physics/B_SpeedOfSound.py
+++ b/psl_res/GUI/D_PHYSICS/B_physics/B_SpeedOfSound.py
@@ -110,7 +110,7 @@ class AppWindow(QtGui.QMainWindow, ui_template_graph_nofft.Ui_MainWindow,utiliti
 			#self.displayCrossHairData(self.plot,False,self.samples,self.I.timebase,[y],[(0,255,0)])
 			self.I.set_state(SQR1=False) #Set SQR1 to 0
 			return 'Done'
-		except Exception,e:
+		except Exception as e:
 			print (e)
 			return 'Error'
 

--- a/psl_res/GUI/E_MISCELLANEOUS/B/calibration_loader.py
+++ b/psl_res/GUI/E_MISCELLANEOUS/B/calibration_loader.py
@@ -422,7 +422,7 @@ class AppWindow(QtGui.QMainWindow, calibration_loader.Ui_MainWindow,utilitiesCla
 					else:
 						print ('Done',V,C,CT)
 						return C
-		except Exception, ex:
+		except Exception as ex:
 			self.displayDialog(ex.message)
 
 

--- a/psl_res/GUI/E_MISCELLANEOUS/B/virtual.py
+++ b/psl_res/GUI/E_MISCELLANEOUS/B/virtual.py
@@ -88,7 +88,7 @@ class AppWindow(QtGui.QMainWindow, remote.Ui_MainWindow):
 				self.results_2.append('%s : %s'%( response.status, response.reason))
 				data = response.read()
 				conn.close()
-			except Exception,e:
+			except Exception as e:
 				self.results_2.append('Error : %s'%( e.message))
 				pass
 
@@ -111,7 +111,7 @@ class AppWindow(QtGui.QMainWindow, remote.Ui_MainWindow):
 				#while self.hw_lock and self.active: pass
 				#self.hw_lock=True
 				self.thingSpeakCommand=[method,total_args]
-		except Exception,e:
+		except Exception as e:
 			self.results_2.append('Set Error : %s'%( e.message))
 			pass
 
@@ -144,7 +144,7 @@ class AppWindow(QtGui.QMainWindow, remote.Ui_MainWindow):
 			elif msg_type == 'R':
 				self.resSlot.emit(str(message),'reply')		
 				
-		except Exception,e:
+		except Exception as e:
 			self.responseLabel.setText (e.message)
 
 	def writeResults(self,txt,t):
@@ -164,7 +164,7 @@ class AppWindow(QtGui.QMainWindow, remote.Ui_MainWindow):
 		if state: #Enable listen
 			try:
 				self.pubnub.subscribe(self.I.hexid,callback = self.callback)
-			except Exception,e:
+			except Exception as e:
 				self.responseLabel.setText (e)
 		else:
 			self.pubnub.unsubscribe(self.I.hexid)			
@@ -175,7 +175,7 @@ class AppWindow(QtGui.QMainWindow, remote.Ui_MainWindow):
 			self.pubnub = Pubnub(
 				publish_key = str(self.pubEdit.text()),
 				subscribe_key = str(self.subEdit.text()))
-		except Exception,e:
+		except Exception as e:
 			self.responseLabel.setText (e)
 
 	def __del__(self):


### PR DESCRIPTION
These changes should be compatible with both Python 2 and Python 3.
* Old style exceptions --> new style
* Define __unicode()__ in Python 3
* Define __xrange()__ in Python 3
* Removed a few unused imports (Codacy seems to like that)
* Ran __isort__ on a few confusing import blocks

Some issues remain...
[flake8](http://flake8.pycqa.org) testing of https://github.com/fossasia/pslab-desktop-apps on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
flake8 . $F8OPTS
./PSL_Apps/utilitiesClass.py:1386:12: F821 undefined name 'a'
		if link: a['LINK'] = link
           ^
./psl_res/GUI/E_MISCELLANEOUS/B/calibrator.py:345:12: F821 undefined name 'r'
		if c and r:
           ^
./psl_res/GUI/E_MISCELLANEOUS/B/ADS1115calibrator.py:297:12: F821 undefined name 'r'
		if c and r:
           ^
./psl_res/GUI/E_MISCELLANEOUS/B/J_stepper.py:71:10: F821 undefined name 'MyMainWindow'
	myapp = MyMainWindow()
         ^
4     F821 undefined name 'a'
4
```